### PR TITLE
updated direct waits to smart waits

### DIFF
--- a/HW25/web_project/pages/login_page.py
+++ b/HW25/web_project/pages/login_page.py
@@ -1,10 +1,15 @@
 from random import randint
+import time
+
 from selenium.webdriver import ActionChains
 from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.webdriver import WebDriver
-import time
-from web_project.helpers.helper_config import get_base_url
+from selenium.webdriver.support.wait import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+
 from web_project.pages.base_page import BasePage
+from web_project.helpers.helper_config import get_base_url
+
 
 path = '/home/helga/Hillel_QA/drivers/chromedriver/chromedriver'
 
@@ -81,7 +86,7 @@ class LoginPage(BasePage):
 
     def perform_successful_login(self,valid_user,email_flag=False, change_password=False, change_login=False):
         if change_login:
-            valid_user.login += 2* chr(randint(65,90))
+            valid_user.login += 2 * chr(randint(65,90))
         if change_password:
             valid_user.password += chr(randint(65,90))
 
@@ -95,7 +100,8 @@ class LoginPage(BasePage):
         self.enter_password (valid_user.password)
 
         self.click_login_button()
-        time.sleep(5)
+
+        WebDriverWait(self.driver, 5).until(EC.visibility_of_all_elements_located((By.XPATH, "//span[@class='b-tophead-dropdown']")))
 
         return self
 
@@ -108,7 +114,6 @@ class LoginPage(BasePage):
             self.enter_login(user.login)
         self.enter_password (user.password)
         self.click_login_button()
-        time.sleep (2)
         return self
 
 
@@ -119,10 +124,10 @@ class LoginPage(BasePage):
 
     def get_profile_email_field(self):
         ''' Check if user's email in profile email field is concordant to the email user was registered with '''
-
         profile_email_field = self.element_is_present(LoginPage.PROFILE_EMAIL_FIELD_LOCATOR)
         email_value = profile_email_field.get_attribute('value')
         return email_value
+
 
     def perform_logout(self):
         action = ActionChains(self.driver)

--- a/HW25/web_project/pages/register_page.py
+++ b/HW25/web_project/pages/register_page.py
@@ -1,9 +1,14 @@
-
-from selenium.webdriver.remote.webdriver import WebDriver
-from selenium.webdriver.common.by import By
-from web_project.helpers.helper_config import get_base_url
-from web_project.pages.base_page import BasePage
 import time
+
+from selenium.webdriver.common.by import By
+from selenium.webdriver.remote.webdriver import WebDriver
+from selenium.webdriver.support.wait import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+
+from web_project.helpers.helper_config import get_base_url
+from web_project.helpers.resources import Resources
+from web_project.pages.base_page import BasePage
+
 
 class RegisterPage(BasePage):
 
@@ -15,6 +20,7 @@ class RegisterPage(BasePage):
     SUBMIT_BUTTON_LOCATOR = (By.XPATH, "//button[@name='submit']")
     EMAIL_INVALIDITY_CHECKER_LOCATOR = (By.CSS_SELECTOR, '#result-registration-email span.string-error')
     LOGIN_INVALIDITY_CHECKER_LOCATOR = (By.CSS_SELECTOR, '#result-registration-login span.string-error')
+    REGISTER_ERROR_LIST = (By.ID, 'register-popup-errors')
     PASSWORD_INVALIDITY_CHECKER_LOCATOR = (By.CSS_SELECTOR,'#register-popup-errors ul li:nth-child(3)')
     EMPTY_NAME_ERROR_LOCATOR = (By.CSS_SELECTOR,'#register-popup-errors ul li:first-child')
     LOGIN_FIELD_ERROR_LOCATOR = (By.CSS_SELECTOR, '#register-popup-errors ul li:nth-child(2)')
@@ -31,27 +37,27 @@ class RegisterPage(BasePage):
 
     @property
     def register_link(self):
-        return self.element_is_present (RegisterPage.REGISTER_LINK_LOCATOR)
+        return self.element_is_present(RegisterPage.REGISTER_LINK_LOCATOR)
 
     @property
     def register_form(self):
-        return self.element_is_present (RegisterPage.REGISTER_FORM_LOCATOR)
+        return self.element_is_present(RegisterPage.REGISTER_FORM_LOCATOR)
 
     @property
     def input_register_email(self):
-        return self.element_is_present (RegisterPage.INPUT_REGISTER_EMAIL_LOCATOR)
+        return self.element_is_present(RegisterPage.INPUT_REGISTER_EMAIL_LOCATOR)
 
     @property
     def input_register_login(self):
-        return self.element_is_present (RegisterPage.INPUT_REGISTER_LOGIN_LOCATOR)
+        return self.element_is_present(RegisterPage.INPUT_REGISTER_LOGIN_LOCATOR)
 
     @property
     def input_register_password(self):
-        return self.element_is_present (RegisterPage.INPUT_REGISTER_PASSWORD)
+        return self.element_is_present(RegisterPage.INPUT_REGISTER_PASSWORD)
 
     @property
     def submit_button(self):
-        return self.element_is_present (RegisterPage.SUBMIT_BUTTON_LOCATOR)
+        return self.element_is_present(RegisterPage.SUBMIT_BUTTON_LOCATOR)
 
     @property
     def email_invalidity_checker(self):
@@ -59,42 +65,42 @@ class RegisterPage(BasePage):
 
     @property
     def login_invalidity_checker(self):
-        return self.element_is_present (RegisterPage.LOGIN_INVALIDITY_CHECKER_LOCATOR)
+        return self.element_is_present(RegisterPage.LOGIN_INVALIDITY_CHECKER_LOCATOR)
 
     @property
     def password_invalidity_checker(self):
-        return self.element_is_present (RegisterPage.PASSWORD_INVALIDITY_CHECKER_LOCATOR)
+        return self.element_is_present(RegisterPage.PASSWORD_INVALIDITY_CHECKER_LOCATOR)
 
     @property
     def empty_name_error(self):
-        return self.element_is_present (RegisterPage.EMPTY_NAME_ERROR_LOCATOR)
+        return self.element_is_present(RegisterPage.EMPTY_NAME_ERROR_LOCATOR)
 
     @property
     def login_field_error(self):
-        return self.element_is_present (RegisterPage.LOGIN_FIELD_ERROR_LOCATOR)
+        return self.element_is_present(RegisterPage.LOGIN_FIELD_ERROR_LOCATOR)
 
     @property
     def email_field_error(self):
-        return self.element_is_present (RegisterPage.EMAIL_FIELD_ERROR_LOCATOR)
+        return self.element_is_present(RegisterPage.EMAIL_FIELD_ERROR_LOCATOR)
 
     @property
     def email_field_notification(self):
-        return self.element_is_present (RegisterPage.EMAIL_FIELD_NOTIFICATION_LOCATOR)
+        return self.element_is_present(RegisterPage.EMAIL_FIELD_NOTIFICATION_LOCATOR)
 
     @property
     def login_field_notification(self):
-        return self.element_is_present (RegisterPage.LOGIN_FIELD_NOTIFICATION_LOCATOR)
+        return self.element_is_present(RegisterPage.LOGIN_FIELD_NOTIFICATION_LOCATOR)
     @property
     def email_label(self):
-        return self.element_is_present (RegisterPage.EMAIL_LABEL_LOCATOR)
+        return self.element_is_present(RegisterPage.EMAIL_LABEL_LOCATOR)
 
     @property
     def login_label(self):
-        return self.element_is_present (RegisterPage.LOGIN_LABEL_LOCATOR)
+        return self.element_is_present(RegisterPage.LOGIN_LABEL_LOCATOR)
 
     @property
     def password_label(self):
-        return self.element_is_present (RegisterPage.PASSWORD_LABEL_LOCATOR)
+        return self.element_is_present(RegisterPage.PASSWORD_LABEL_LOCATOR)
 
     def navigate(self):
         self.driver.get(get_base_url())
@@ -108,18 +114,20 @@ class RegisterPage(BasePage):
 
     def enter_invalid_email(self,invalid_register_email):
         self.input_register_email.send_keys(invalid_register_email)
-        time.sleep(5)
+        WebDriverWait(self.driver, 5).until(
+            lambda wd: wd.find_element(*RegisterPage.EMAIL_INVALIDITY_CHECKER_LOCATOR).text == Resources.RegisterPage.EMAIL_INVALIDITY_MESSAGE)
         self.click_submit_button()
 
 
     def enter_invalid_login(self,invalid_register_login):
         self.input_register_login.send_keys(invalid_register_login)
-        time.sleep(5)
+        WebDriverWait(self.driver, 5).until(
+            lambda wd: wd.find_element(*RegisterPage.LOGIN_INVALIDITY_CHECKER_LOCATOR).text == Resources.RegisterPage.LOGIN_INVALIDITY_MESSAGE)
         self.click_submit_button()
 
     def enter_invalid_password(self,invalid_register_password):
         self.input_register_password.send_keys(invalid_register_password)
-        time.sleep(5)
+        # time.sleep(5)  # No wait is needed here - app doesn't changed
         self.click_submit_button()
 
 
@@ -129,15 +137,5 @@ class RegisterPage(BasePage):
     def perform_unsuccessfull_registration_with_empty_credentials_fields(self):
         self.open_register_form()
         self.click_submit_button()
-        time.sleep(3)
-
-
-
-
-
-
-
-
-
-
+        WebDriverWait(self.driver, 5).until(EC.visibility_of_all_elements_located(RegisterPage.REGISTER_ERROR_LIST))
 

--- a/HW25/web_project/tests/test_login_page.py
+++ b/HW25/web_project/tests/test_login_page.py
@@ -35,12 +35,12 @@ def test_user_cant_login_with_unregistered_email(driver, login_page, unregistere
 
 
 def test_user_cant_login_with_correct_login_and_incorrect_password(driver, login_page, valid_user):
-    login_page.perform_successful_login(valid_user,change_password=True)
+    login_page.perform_successful_login(valid_user,change_password=True)  # Why here successful login used if we enter incorrect login?
     assert login_page.login_invalid_creds_error.is_displayed()
     assert login_page.login_invalid_creds_error.text == Resources.LoginPage.INCORRECT_CREDS_ERROR_MESSAGE
 
 def test_user_cant_login_with_incorrect_login_and_correct_password(driver, login_page,valid_user):
-    login_page.perform_successful_login(valid_user, change_login=True)
+    login_page.perform_successful_login(valid_user, change_login=True)  # Why here successful login used if we enter incorrect login?
     assert login_page.login_invalid_creds_error.is_displayed()
     assert login_page.login_invalid_creds_error.text == Resources.LoginPage.INCORRECT_CREDS_ERROR_MESSAGE
 


### PR DESCRIPTION
2 tests failing now:
FAILED tests\test_login_page.py::test_user_cant_login_with_correct_login_and_incorrect_password
FAILED tests\test_login_page.py::test_user_cant_login_with_incorrect_login_and_correct_password
Need to revise perform_successful_login method so it could be used only for successful login, currently it contains logic to login with invalid credentials and doesn't perform successful login. Need to follow single responcibility principle.